### PR TITLE
0.1.2

### DIFF
--- a/Fallible.Tests/ErrorTests.cs
+++ b/Fallible.Tests/ErrorTests.cs
@@ -1,12 +1,11 @@
-﻿using Fallible;
-using Xunit;
+﻿using Xunit;
 
-namespace Errors.Tests;
+namespace Fallible.Tests;
 
 public class ErrorTests
 {
-    // Instantiation
-    
+    #region Instantiation Tests
+
     [Fact]
     public void WhenCreated_ShouldHaveMessage()
     {
@@ -26,7 +25,9 @@ public class ErrorTests
         Assert.Contains(expectedStackTraceSubstring, error.StackTrace);
     }
     
-    // Conversion
+    #endregion
+
+    #region Conversion Tests
 
     [Fact]
     public void WhenCreated_BoolConversion_ShouldReturnTrue()
@@ -44,8 +45,10 @@ public class ErrorTests
         Assert.False(error);
     }
 
-    // Equability
-    
+    #endregion
+
+    #region Equability Tests
+
     [Fact]
     public void WhenEquated_GivenSameInstance_ShouldReturnTrue()
     {
@@ -110,4 +113,32 @@ public class ErrorTests
         
         Assert.True(result);
     }
+
+    #endregion
+
+    #region ToString Tests
+
+    [Fact]
+    public void ToString_ContainsMessage()
+    {
+        var expectedSubstring = "Test";
+        var error = new Error(expectedSubstring);
+        
+        var result = error.ToString();
+        
+        Assert.Contains(expectedSubstring, result);
+    }
+    
+    [Fact]
+    public void ToString_ContainsStackTrace()
+    {
+        var expectedSubstring = "at Fallible.Error..ctor";
+        var error = new Error("Test");
+        
+        var result = error.ToString();
+        
+        Assert.Contains(expectedSubstring, result);
+    }
+
+    #endregion
 }

--- a/Fallible.Tests/Fallible.Tests.csproj
+++ b/Fallible.Tests/Fallible.Tests.csproj
@@ -6,7 +6,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <RootNamespace>Errors.Tests</RootNamespace>
+        <RootNamespace>Fallible.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Fallible.Tests/FallibleTests.cs
+++ b/Fallible.Tests/FallibleTests.cs
@@ -136,7 +136,7 @@ public class FallibleTests
             return arg + 3;
         };
 
-        var result = Fallible.FromCall(() => func(42));
+        var result = Fallible.Try(() => func(42));
 
         Assert.NotNull(result.Error);
     }
@@ -150,7 +150,7 @@ public class FallibleTests
             return arg + 3;
         };
 
-        var (value, error) = Fallible.FromCall(() => func(41));
+        var (value, error) = Fallible.Try(() => func(41));
 
         Assert.Null(error);
         Assert.Equal(44, value);
@@ -165,7 +165,7 @@ public class FallibleTests
             return arg + 3;
         };
 
-        var (_, error) = Fallible.FromCall(() => func(42));
+        var (_, error) = Fallible.Try(() => func(42));
         
         Assert.Contains("() => func(42)", error.Message);
     }

--- a/Fallible.Tests/FallibleTests.cs
+++ b/Fallible.Tests/FallibleTests.cs
@@ -1,10 +1,12 @@
-﻿using Fallible;
+﻿using System;
 using Xunit;
 
-namespace Errors.Tests;
+namespace Fallible.Tests;
 
 public class FallibleTests
 {
+    #region Instantiation Tests
+
     [Fact]
     public void WhenCreated_ContainsError()
     {
@@ -36,6 +38,10 @@ public class FallibleTests
         Assert.Null(fallible.Value);
     }
 
+    #endregion
+
+    #region Deconstruction Tests
+
     [Fact]
     public void CanBeDeconstructed_ValueIsDefault()
     {
@@ -62,12 +68,17 @@ public class FallibleTests
     public void CanBeDeconstructed_ValueIsExpected()
     {
         var expectedValue = 42;
-        
-        var (value, _) = ReturnValue_ViaImplicitConversion(expectedValue);
+        Fallible<int> fallible = expectedValue;
+
+        var (value, _) = fallible;
         
         Assert.Equal(expectedValue, value);
     }
-    
+
+    #endregion
+
+    #region Conversion Tests
+
     [Fact]
     public void CanBeImplicitlyConverted_FromValue()
     {
@@ -112,8 +123,52 @@ public class FallibleTests
         Assert.IsType<Fallible<object>>(fallible);
     }
 
-    private static Fallible<T> ReturnValue_ViaImplicitConversion<T>(T value)
+    #endregion
+
+    #region Static Method Tests
+
+    [Fact]
+    public void FromCall_ShouldCatchException_AndReturnError()
     {
-        return value;
+        var func = (int arg) =>
+        {
+            if (arg == 42) throw new Exception();
+            return arg + 3;
+        };
+
+        var result = Fallible.FromCall(() => func(42));
+
+        Assert.NotNull(result.Error);
     }
+    
+    [Fact]
+    public void FromCall_ShouldReturnValue_WhenNoException()
+    {
+        var func = (int arg) =>
+        {
+            if (arg == 42) throw new Exception();
+            return arg + 3;
+        };
+
+        var (value, error) = Fallible.FromCall(() => func(41));
+
+        Assert.Null(error);
+        Assert.Equal(44, value);
+    }
+    
+    [Fact]
+    public void FromCall_ShouldHaveErrorMessage_ContainingExpression()
+    {
+        var func = (int arg) =>
+        {
+            if (arg == 42) throw new Exception();
+            return arg + 3;
+        };
+
+        var (_, error) = Fallible.FromCall(() => func(42));
+        
+        Assert.Contains("() => func(42)", error.Message);
+    }
+
+    #endregion
 }

--- a/Fallible/Error.cs
+++ b/Fallible/Error.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Fallible;
 
@@ -46,5 +47,14 @@ public class Error : IEquatable<Error>
     public override int GetHashCode()
     {
         return HashCode.Combine(Message, _callingFilePath, _callingMemberName, _callingLineNumber);
+    }
+
+    public override string ToString()
+    {
+        var stringBuilder = new StringBuilder();
+        stringBuilder.AppendLine(Message);
+        stringBuilder.AppendLine(StackTrace);
+
+        return stringBuilder.ToString();
     }
 }

--- a/Fallible/Fallible.cs
+++ b/Fallible/Fallible.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Fallible;
+
+#region Generic Struct
 
 public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
 {
@@ -46,3 +49,25 @@ public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
 
     public int Length => 2;
 }
+
+#endregion
+
+#region Static Class
+
+public static class Fallible
+{
+    public static Fallible<TResult> FromCall<TResult>(Func<TResult> action, [CallerArgumentExpression("action")] string expression = "")
+    {
+        try
+        {
+            var value = action();
+            return value;
+        }
+        catch (Exception e)
+        {
+            return new Error($"{expression} threw {e.GetType().Name}: {e.Message}");
+        }
+    }
+}
+
+#endregion

--- a/Fallible/Fallible.cs
+++ b/Fallible/Fallible.cs
@@ -56,7 +56,7 @@ public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
 
 public static class Fallible
 {
-    public static Fallible<TResult> FromCall<TResult>(Func<TResult> action, [CallerArgumentExpression("action")] string expression = "")
+    public static Fallible<TResult> Try<TResult>(Func<TResult> action, [CallerArgumentExpression("action")] string expression = "")
     {
         try
         {

--- a/README.md
+++ b/README.md
@@ -109,24 +109,30 @@ if (error)
 // continue with result
 ```
 
-# Final Notes
+### Making calls to exception throwing methods
 
-If you are using this library in your project, it does not mean that you can not use exceptions. Exceptions are still an effective way of quickly returning up the call stack when the application is in a serious erroneous state. This usage would be similar to `panic()` in Go.
+It is important to keep in mind that even if you are using this library throughout your entire application, external dependencies may not and exceptions could still be thrown when the call stack leaves your domain. Fallible includes a handy static factory method to wrap the call into a closure and have it catch any exceptions and convert them into an `Error` object.
 
-It is also important to keep in mind that even though you are using this library throughout your entire application, external dependencies may not and exceptions could still be thrown when the call stack leaves your domain.
+For example, `DateTime.Parse` can throw two exceptions: `FormatException` and `ArgumentNullException`. To intercept these exceptions and convert them into an `Error` object, you can do the following:
 
-I hope you enjoy using this library and find it an enjoyable addition to the C# coding experience.
+```c#
+var (result, error) = Fallible.Try(() => DateTime.Parse("1/1/2019"));
+```
 
-## Future Work
+## Final Notes
 
-### Error Handling
+If you are using this library in your project, it does not mean that you can not use exceptions. Exceptions are still an effective way of quickly returning up the call stack when the application is in a serious erroneous state. This usage would be similar to `panic()` in Go. I hope you enjoy using this library and find it an enjoyable addition to the C# coding experience.
+
+### Future Work
+
+#### Error Handling
 
 I am considering adding in utility classes to make it easier to handle error states and reduce the amount of boilerplate that the pattern creates. Although it is already minimal, some usages of the library may show the need for these classes.
 
-### Error Aggregation
+#### Error Aggregation
 
 While typically an application will exit early upon encountering an error state, it could sometimes be beneficial to continue processing and aggregate all the error states into a single error state. This could be useful for example if you are validating a series of values and you want to collect everything wrong about a particular call before exiting.
 
-### Extensions to the Standard Library
+#### Extensions to the Standard Library
 
 Adding extension methods to the standard library is a potential improvement for the library. For example, `bool Try(out value)` type methods could be extended to support `Fallible<T> Try()` signatures.


### PR DESCRIPTION
- `Error` class now implements its own `ToString` method.
- New `Fallible<T> Fallible.Try(Func<T> closure)` method to catch exceptions and wrap them into a `Fallible<T>` object.