### PR TITLE
0.1.3

### DIFF
--- a/Fallible.Tests/FallibleTests.cs
+++ b/Fallible.Tests/FallibleTests.cs
@@ -16,7 +16,7 @@ public class FallibleTests
         
         Assert.Equal(error, fallible.Error);
     }
-    
+
     [Fact]
     public void WhenCreated_ContainsDefaultValue_WhenValueType()
     {
@@ -75,6 +75,16 @@ public class FallibleTests
         Assert.Equal(expectedValue, value);
     }
 
+    [Fact]
+    public void CanBeDeconstructed_ShouldHaveNullResult_WhenVoidReturn()
+    {
+        Fallible<Void> fallible = new Error("Wrong Number");
+        
+        var (result, _) = fallible;
+        
+        Assert.Null(result);
+    }
+
     #endregion
 
     #region Conversion Tests
@@ -121,6 +131,17 @@ public class FallibleTests
         Fallible<object> fallible = (null, error);
         
         Assert.IsType<Fallible<object>>(fallible);
+    }
+
+    [Fact]
+    public void CanBeImplicitlyConverted_FromVoid_WhenReturning()
+    {
+        var func = Fallible<Void>() => Fallible.Return;
+
+        Fallible<Void> fallible = func();
+        
+        Assert.IsType<Fallible<Void>>(fallible);
+
     }
 
     #endregion

--- a/Fallible/Fallible.csproj
+++ b/Fallible/Fallible.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.1.2</PackageVersion>
+        <PackageVersion>0.1.3</PackageVersion>
         <Title>Fallible</Title>
         <Authors>Tom van Dinther</Authors>
         <Description>An idiomatic way to explicitly define, propagate and handle error states in C#. This library is inspired by Go's errors.</Description>

--- a/Fallible/FallibleGenericStruct.cs
+++ b/Fallible/FallibleGenericStruct.cs
@@ -4,8 +4,6 @@ using System.Text;
 
 namespace Fallible;
 
-#region Generic Struct
-
 public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
 {
     public T Value { get; }
@@ -17,7 +15,11 @@ public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
         Error = error;
     }
 
-    public static implicit operator Fallible<T>(Error error) => new(default!, error);
+    public static implicit operator Fallible<T>(Error error)
+    {
+        return new(default!, error);
+    }
+
     public static implicit operator Fallible<T>(T value) => new(value, default!);
     public static implicit operator Fallible<T>((T? value, Error? error) tuple) => new(tuple.value!, tuple.error!);
 
@@ -49,25 +51,3 @@ public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
 
     public int Length => 2;
 }
-
-#endregion
-
-#region Static Class
-
-public static class Fallible
-{
-    public static Fallible<TResult> Try<TResult>(Func<TResult> action, [CallerArgumentExpression("action")] string expression = "")
-    {
-        try
-        {
-            var value = action();
-            return value;
-        }
-        catch (Exception e)
-        {
-            return new Error($"{expression} threw {e.GetType().Name}: {e.Message}");
-        }
-    }
-}
-
-#endregion

--- a/Fallible/FallibleStatic.cs
+++ b/Fallible/FallibleStatic.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace Fallible;
+
+public static class Fallible
+{
+    public static Fallible<TResult> Try<TResult>(Func<TResult> action, [CallerArgumentExpression("action")] string expression = "")
+    {
+        try
+        {
+            var value = action();
+            return value;
+        }
+        catch (Exception e)
+        {
+            return new Error($"{expression} threw {e.GetType().Name}: {e.Message}");
+        }
+    }
+
+    public static Fallible<Void> Return => new Void();
+}

--- a/Fallible/Void.cs
+++ b/Fallible/Void.cs
@@ -1,0 +1,6 @@
+namespace Fallible;
+
+public class Void
+{
+    internal Void() { }
+}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ public Fallible<int> GetValue(int arg)
 }
 ```
 
+#### Returning `void`
+
+Fallible includes a `void` type that can be used to return *void* from a method. It does not have an accessible constructor and can only be created by using the `Fallible.Return` property.
+
+```c#
+public Fallible<Void> DoSomething()
+{
+    // Do something
+    if (somethingFailed) return new Error("Something went wrong");
+    
+    return Fallible.Return;
+}
+```
+
 ### Working with `Fallible<T>`
 
 When working with a `Fallible<T>` type returned by a method, it is best to deconstruct it upon assignment and then perform a check on the error state. `Error` contains an implicit boolean conversion operator that returns `true` if the error state is not `null`.


### PR DESCRIPTION
Fallible now includes a `void` type that can be used to return *void* from a method. It does not have an accessible constructor and can only be created by using the `Fallible.Return` property.

```c#
public Fallible<Void> DoSomething()
{
    // Do something
    if (somethingFailed) return new Error("Something went wrong");
    
    return Fallible.Return;
}
```