### PR TITLE
Add implicit unwrapping and remove tuple conversion

### DIFF
--- a/Fallible.Tests/FallibleTests.cs
+++ b/Fallible.Tests/FallibleTests.cs
@@ -104,34 +104,6 @@ public class FallibleTests
         
         Assert.IsType<Fallible<int>>(fallible);
     }
-    
-    [Fact]
-    public void CanBeImplicitlyConverted_FromTuple_WhenErrorIsNull()
-    {
-        Fallible<int> fallible = (42, null);
-        
-        Assert.IsType<Fallible<int>>(fallible);
-    }
-    
-    [Fact]
-    public void CanBeImplicitlyConverted_FromTuple_WhenValueIsDefault()
-    {
-        var error = new Error("Wrong Number");
-        
-        Fallible<int> fallible = (default, error);
-        
-        Assert.IsType<Fallible<int>>(fallible);
-    }
-    
-    [Fact]
-    public void CanBeImplicitlyConverted_FromTuple_WhenValueIsNull()
-    {
-        var error = new Error("Wrong Number");
-        
-        Fallible<object> fallible = (null, error);
-        
-        Assert.IsType<Fallible<object>>(fallible);
-    }
 
     [Fact]
     public void CanBeImplicitlyConverted_FromVoid_WhenReturning()
@@ -142,6 +114,52 @@ public class FallibleTests
         
         Assert.IsType<Fallible<Void>>(fallible);
 
+    }
+    
+    [Fact]
+    public void WhenWrapped_ShouldUnwrapItselfImplicitly()
+    {
+        Fallible<int> inner = 42;
+        Fallible<Fallible<int>> outer = inner;
+        
+        Fallible<int> result = outer;
+
+        Assert.IsType<Fallible<int>>(result);
+    }
+    
+    [Fact]
+    public void WhenImplicitlyUnwrapped_ShouldContainInnerValue()
+    {
+        const int expectedValue = 42;
+        Fallible<int> inner = expectedValue;
+        Fallible<Fallible<int>> outer = inner;
+        
+        Fallible<int> result = outer;
+
+        Assert.Equal(expectedValue, result.Value);
+    }
+
+    [Fact]
+    public void WhenImplicitlyUnwrapped_ShouldContainCorrectError_WhenInnerErrorIsPresent()
+    {
+        var expectedError = new Error("Inner Error");
+        Fallible<int> inner = expectedError;
+        Fallible<Fallible<int>> outer = inner;
+        
+        Fallible<int> result = outer;
+
+        Assert.Equal(expectedError, result.Error);
+    }
+
+    [Fact]
+    public void WhenImplicitlyUnwrapped_ShouldContainError_WhenOuterErrorIsPresent()
+    {
+        var expectedError = new Error("Outer Error");
+        Fallible<Fallible<int>> outer = expectedError;
+        
+        Fallible<int> result = outer;
+
+        Assert.Equal(expectedError, result.Error);
     }
 
     #endregion

--- a/Fallible/Fallible.csproj
+++ b/Fallible/Fallible.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.1.4</PackageVersion>
+        <PackageVersion>0.1.5</PackageVersion>
         <Title>Fallible</Title>
         <Authors>Tom van Dinther</Authors>
         <Description>An idiomatic way to explicitly define, propagate and handle error states in C#. This library is inspired by Go's errors.</Description>

--- a/Fallible/FallibleGenericStruct.cs
+++ b/Fallible/FallibleGenericStruct.cs
@@ -15,13 +15,9 @@ public readonly record struct Fallible<T> : IStructuralEquatable, ITuple
         Error = error;
     }
 
-    public static implicit operator Fallible<T>(Error error)
-    {
-        return new(default!, error);
-    }
-
+    public static implicit operator Fallible<T>(Error error) => new(default!, error);
     public static implicit operator Fallible<T>(T value) => new(value, default!);
-    public static implicit operator Fallible<T>((T? value, Error? error) tuple) => new(tuple.value!, tuple.error!);
+    public static implicit operator Fallible<T>(Fallible<Fallible<T>> outer) => outer.Error ? outer.Error : outer.Value;
 
     public void Deconstruct(out T value, out Error error)
     {

--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ Although, if the error's message was constructed using dynamic arguments, the er
 
 ### `Fallible<T>`
 
-`Fallible<T>` is a readonly record struct meaning that it is immutable, is identified by its properties and is allocated on the stack. It can not be created directly. To create a `Fallible<T>` object you can cast either explicitly or implicitly from one of the following three types.
-
-- `T`
-- `Error`
-- `(T?, Error?)`
+`Fallible<T>` is a readonly record struct meaning that it is immutable, is identified by its properties and is allocated on the stack. It can not be created directly. To create a `Fallible<T>` object you can cast either explicitly or implicitly from `T` or `Error`. Using a cast from only these two types as the only way to create a `Fallible<T>` object ensures that we always have either an error or a value.
 
 This gives the succinct interface for the creation of a `Fallible<T>` object as per the examples below.
 
@@ -84,15 +80,6 @@ public Fallible<int> GetValue(int arg)
     if (arg == 42) return new Error("Can't work with 42");
     
     return arg + 3;
-}
-```
-or
-```c#
-public Fallible<int> GetValue(int arg)
-{
-    if (arg == 42) return (default, new Error("Can't work with 42"));
-    
-    return (arg + 3, null);
 }
 ```
 
@@ -122,6 +109,10 @@ if (error)
 }
 // continue with result
 ```
+
+#### Implicit Unwrapping
+
+You may want to use the `Fallible<T>` type in a wrapper function. If the wrapped function also returns a `Fallible<T>` type, an implicit conversion will automatically unwrap `Fallible<Fallible<T>>` into `Fallible<T>`.
 
 ### Making calls to exception throwing methods
 


### PR DESCRIPTION
Conversion for implicit unwrapping is added to facilitate usage in wrapper functions. The tuple conversion is also removed to better enforce the two possible states (Failed, Not Failed).